### PR TITLE
Switch to edition 2018 to support Rust v1.54.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,7 @@ dependencies = [
  "log",
  "md-5",
  "path-absolutize",
+ "path-dedot",
  "regex",
  "tempfile",
 ]
@@ -275,18 +276,18 @@ checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
 name = "path-absolutize"
-version = "3.0.13"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3de4b40bd9736640f14c438304c09538159802388febb02c8abaae0846c1f13"
+checksum = "b288298a7a3a7b42539e3181ba590d32f2d91237b0691ed5f103875c754b3bf5"
 dependencies = [
  "path-dedot",
 ]
 
 [[package]]
 name = "path-dedot"
-version = "3.0.17"
+version = "3.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d611d5291372b3738a34ebf0d1f849e58b1dcc1101032f76a346eaa1f8ddbb5b"
+checksum = "4bfa72956f6be8524f7f7e2b07972dda393cb0008a6df4451f658b7e1bd1af80"
 dependencies = [
  "once_cell",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,15 @@ version = "0.1.0"
 authors = ["majorz"]
 description = "Safe file read and write for FAT filesystems"
 license = "Apache-2.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 clap = { version = "3", features = ["derive"] }
 env_logger = "0.9"
 anyhow = "1"
 md-5 = "0.10"
-path-absolutize = "3"
+path-absolutize = "=3.0.11"
+path-dedot = "=3.0.14"
 regex = "1"
 tempfile = "3"
 getrandom = "0.2"


### PR DESCRIPTION
Signed-off-by: Zahari Petkov <zahari@balena.io>