### PR TITLE
Remove panic="abort" as it breaks meta-rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,4 @@ default-features = false
 [profile.release]
 opt-level = "z"
 lto = true
-panic = "abort"
 codegen-units = 1


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Zahari Petkov <zahari@balena.io>