### PR TITLE
Do not use custom release profile for CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,17 +44,17 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: --profile release-static --target ${{ matrix.target }}
+          args: --profile release --target ${{ matrix.target }}
 
       - name: Install LLVM
         run: sudo apt-get install -y llvm
 
       - name: LLVM strip
-        run: llvm-strip target/${{ matrix.target }}/release-static/fatrw
+        run: llvm-strip target/${{ matrix.target }}/release/fatrw
 
       - name: Compress
         run: |
-          tar -czvf fatrw-${{ matrix.balena-arch }}.tar.gz -C target/${{ matrix.target }}/release-static fatrw
+          tar -czvf fatrw-${{ matrix.balena-arch }}.tar.gz -C target/${{ matrix.target }}/release fatrw
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,3 @@ default-features = false
 [profile.release]
 opt-level = "z"
 codegen-units = 1
-
-[profile.release-static]
-inherits = "release"
-lto = true
-panic = "abort"


### PR DESCRIPTION
Removing the custom profile as it confuses the yocto builds.

Change-type: patch
Signed-off-by: Zahari Petkov <zahari@balena.io>