### PR TITLE
Fix clippy warnings introduced in Rust 1.67

### DIFF
--- a/src/bin/fatrw/main.rs
+++ b/src/bin/fatrw/main.rs
@@ -21,14 +21,14 @@ fn main() -> Result<()> {
         Command::Write { path, mode } => {
             let mut input = Vec::new();
             stdin().read_to_end(&mut input)?;
-            write_file(&path, &input, mode_from_string(&mode)?)
+            write_file(path, &input, mode_from_string(&mode)?)
         }
         Command::Read { path } => {
-            let content = read_file(&path)?;
+            let content = read_file(path)?;
             stdout().write_all(&content)?;
             Ok(())
         }
-        Command::Copy { source, dest } => copy_file(&source, &dest),
+        Command::Copy { source, dest } => copy_file(source, dest),
     }
 }
 

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -29,7 +29,7 @@ pub fn generate_md5sum_path(path: &Path, checksum: &str) -> Result<PathBuf> {
 
     let target_name = get_file_name(path)?;
 
-    let md5sum_name = format!(".{}.{}.{}.md5sum", target_name, random_suffix, checksum);
+    let md5sum_name = format!(".{target_name}.{random_suffix}.{checksum}.md5sum");
     debug!("Checksum file {}", md5sum_name);
 
     let md5sum_path = path.with_file_name(md5sum_name);

--- a/src/random.rs
+++ b/src/random.rs
@@ -7,7 +7,7 @@ pub fn generate_random_string() -> String {
     let mut string = String::new();
     let buf = generate_random_buf();
     for num in &buf {
-        write!(string, "{:02x}", num).expect("Failed to write hex number");
+        write!(string, "{num:02x}").expect("Failed to write hex number");
     }
     string
 }

--- a/src/read.rs
+++ b/src/read.rs
@@ -29,7 +29,7 @@ fn process_md5sums(path: &Path) -> Option<Vec<u8>> {
     let parent = get_parent_as_string(path).ok()?;
     debug!("Parent directory {}", parent);
 
-    let pattern = format!("{}/.{}.*.*.md5sum", parent, file_name);
+    let pattern = format!("{parent}/.{file_name}.*.*.md5sum");
     debug!("Glob pattern {}", pattern);
 
     let mut content = None;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -35,12 +35,12 @@ fn read_md5sum() {
 
     let checksum = md5sum(test_md5sum_content);
 
-    let md5sum_name = format!(".test.txt.1234abcd.{}.md5sum", checksum);
-    let md5sum_path = temp.join(&md5sum_name);
+    let md5sum_name = format!(".test.txt.1234abcd.{checksum}.md5sum");
+    let md5sum_path = temp.join(md5sum_name);
     create_file(&md5sum_path, test_md5sum_content);
 
-    let tmp_name = format!(".test.txt.1234abcd.{}.tmp", checksum);
-    let tmp_path = temp.join(&tmp_name);
+    let tmp_name = format!(".test.txt.1234abcd.{checksum}.tmp");
+    let tmp_path = temp.join(tmp_name);
     create_file(&tmp_path, test_md5sum_content);
 
     let content = read_file(&target).unwrap();
@@ -62,12 +62,12 @@ fn read_multiple_md5sums() {
 
     let checksum = md5sum(test_content);
 
-    let md5sum_name_1 = format!(".test.txt.11111111.{}.md5sum", checksum);
-    let md5sum_path_1 = temp.join(&md5sum_name_1);
+    let md5sum_name_1 = format!(".test.txt.11111111.{checksum}.md5sum");
+    let md5sum_path_1 = temp.join(md5sum_name_1);
     create_file(&md5sum_path_1, test_content);
 
-    let md5sum_name_2 = format!(".test.txt.22222222.{}.md5sum", checksum);
-    let md5sum_path_2 = temp.join(&md5sum_name_2);
+    let md5sum_name_2 = format!(".test.txt.22222222.{checksum}.md5sum");
+    let md5sum_path_2 = temp.join(md5sum_name_2);
     create_file(&md5sum_path_2, test_content);
 
     let target = temp.join("test.txt");


### PR DESCRIPTION
Done automatically with `cargo clippy --fix`

Change-type: patch
Signed-off-by: Zahari Petkov <zahari@balena.io>