### PR TITLE
Handle low disk space scenarios by resorting to unsafe write/rename

### DIFF
--- a/src/bin/fatrw/cli.rs
+++ b/src/bin/fatrw/cli.rs
@@ -13,6 +13,10 @@ pub struct Cli {
     /// Print debug information
     #[clap(short, long)]
     pub debug: bool,
+
+    /// Allow fallback to unsafe write/rename
+    #[clap(short, long = "unsafe")]
+    pub unsafe_fallback: bool,
 }
 
 #[derive(Debug, Subcommand)]

--- a/src/bin/fatrw/main.rs
+++ b/src/bin/fatrw/main.rs
@@ -21,14 +21,14 @@ fn main() -> Result<()> {
         Command::Write { path, mode } => {
             let mut input = Vec::new();
             stdin().read_to_end(&mut input)?;
-            write_file(path, &input, mode_from_string(&mode)?)
+            write_file(path, &input, mode_from_string(&mode)?, cli.unsafe_fallback)
         }
         Command::Read { path } => {
-            let content = read_file(path)?;
+            let content = read_file(path, cli.unsafe_fallback)?;
             stdout().write_all(&content)?;
             Ok(())
         }
-        Command::Copy { source, dest } => copy_file(source, dest),
+        Command::Copy { source, dest } => copy_file(source, dest, cli.unsafe_fallback),
     }
 }
 

--- a/src/bin/fatrw/main.rs
+++ b/src/bin/fatrw/main.rs
@@ -40,6 +40,8 @@ fn init_logging(cli: &Cli) {
 
     if cli.debug {
         builder.filter_level(log::LevelFilter::Debug);
+    } else {
+        builder.filter_level(log::LevelFilter::Info);
     }
 
     builder.init();

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -8,7 +8,11 @@ use crate::fs::get_file_mode;
 use crate::read::read_file;
 use crate::write::write_file;
 
-pub fn copy_file<P: AsRef<Path>, Q: AsRef<Path>>(source: P, dest: Q) -> Result<()> {
+pub fn copy_file<P: AsRef<Path>, Q: AsRef<Path>>(
+    source: P,
+    dest: Q,
+    unsafe_fallback: bool,
+) -> Result<()> {
     debug!(
         "Copy {} {}",
         source.as_ref().display(),
@@ -17,5 +21,10 @@ pub fn copy_file<P: AsRef<Path>, Q: AsRef<Path>>(source: P, dest: Q) -> Result<(
 
     let mode = get_file_mode(source.as_ref()).ok();
 
-    write_file(dest, &read_file(source)?, mode)
+    write_file(
+        dest,
+        &read_file(source, unsafe_fallback)?,
+        mode,
+        unsafe_fallback,
+    )
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,9 +1,10 @@
 use anyhow::{anyhow, Context, Result};
-use log::debug;
+use log::{debug, warn};
 use path_absolutize::Absolutize;
 
 use alloc::borrow::Cow;
 use std::fs::{copy, metadata, read, remove_file, rename, File, OpenOptions};
+use std::io::Result as IOResult;
 use std::io::Write;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::fs::PermissionsExt;
@@ -56,11 +57,31 @@ pub fn commit_md5sum_file(md5sum_path: &Path, path: &Path) -> Result<Vec<u8>> {
 
     let temp_path = md5sum_path.with_extension("tmp");
 
-    copy(md5sum_path, &temp_path).context(format!(
-        "Failed to copy to a temporary location {} -> {}",
-        md5sum_path.display(),
-        temp_path.display()
-    ))?;
+    if let Err(err) = clean_copy(md5sum_path, &temp_path) {
+        if is_storage_full_error(&err) {
+            warn!(
+                "Using unsafe rename due to low space for {}",
+                path.display()
+            );
+
+            rename(md5sum_path, path).context(format!(
+                "Failed to rename md5sum file to target file {} -> {}",
+                md5sum_path.display(),
+                path.display()
+            ))?;
+
+            fsync_parent_dir(path)?;
+
+            return Ok(content);
+        }
+
+        return Err(err).context(format!(
+            "Failed to copy to a temporary location {} -> {}",
+            md5sum_path.display(),
+            temp_path.display()
+        ))?;
+    }
+
     debug!(
         "Copied {} {}",
         file_name_display(md5sum_path),
@@ -120,7 +141,17 @@ pub fn fsync_parent_dir(path: &Path) -> Result<()> {
     Ok(())
 }
 
-pub fn create_file(path: &Path, mode: Option<u32>, content: &[u8]) -> Result<()> {
+pub fn create_file(path: &Path, mode: Option<u32>, content: &[u8]) -> IOResult<()> {
+    if let Err(e) = create_file_unclean(path, mode, content) {
+        // Remove any left over file content in case of failure
+        remove_file(path).ok();
+        return Err(e);
+    }
+
+    Ok(())
+}
+
+fn create_file_unclean(path: &Path, mode: Option<u32>, content: &[u8]) -> IOResult<()> {
     let mut file = open_with_mode(path, mode)?;
 
     file.write_all(content)?;
@@ -131,7 +162,18 @@ pub fn create_file(path: &Path, mode: Option<u32>, content: &[u8]) -> Result<()>
     Ok(())
 }
 
-fn open_with_mode(path: &Path, mode: Option<u32>) -> Result<File> {
+pub fn clean_copy(from: &Path, to: &Path) -> IOResult<u64> {
+    match copy(from, to) {
+        Ok(res) => Ok(res),
+        Err(err) => {
+            // Remove any left over file content in case of failure
+            remove_file(to).ok();
+            Err(err)
+        }
+    }
+}
+
+fn open_with_mode(path: &Path, mode: Option<u32>) -> IOResult<File> {
     let mut open_options = OpenOptions::new();
 
     open_options.create(true).write(true);
@@ -140,9 +182,14 @@ fn open_with_mode(path: &Path, mode: Option<u32>) -> Result<File> {
         open_options.mode(octal_mode);
     }
 
-    Ok(open_options.open(path)?)
+    open_options.open(path)
 }
 
 pub fn file_name_display(path: &Path) -> Cow<'_, str> {
     path.file_name().unwrap_or_default().to_string_lossy()
+}
+
+pub fn is_storage_full_error(err: &std::io::Error) -> bool {
+    // TODO: Use io::ErrorKind::StorageFull when stabilized
+    err.raw_os_error() == Some(28_i32)
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -50,7 +50,11 @@ pub fn get_parent_as_string(path: &Path) -> Result<String> {
     Ok(parent.to_owned())
 }
 
-pub fn commit_md5sum_file(md5sum_path: &Path, path: &Path) -> Result<Vec<u8>> {
+pub fn commit_md5sum_file(
+    md5sum_path: &Path,
+    path: &Path,
+    unsafe_fallback: bool,
+) -> Result<Vec<u8>> {
     debug!("Committing checksum file");
 
     let content = verify_checksum(md5sum_path)?;
@@ -58,7 +62,7 @@ pub fn commit_md5sum_file(md5sum_path: &Path, path: &Path) -> Result<Vec<u8>> {
     let temp_path = md5sum_path.with_extension("tmp");
 
     if let Err(err) = clean_copy(md5sum_path, &temp_path) {
-        if is_storage_full_error(&err) {
+        if unsafe_fallback && is_storage_full_error(&err) {
             warn!(
                 "Using unsafe rename due to low space for {}",
                 path.display()

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,11 +1,13 @@
 use anyhow::{Context, Result};
 
-use log::debug;
+use log::{debug, warn};
 
 use std::path::Path;
 
 use crate::checksum::{generate_md5sum_path, md5sum};
-use crate::fs::{as_absolute, commit_md5sum_file, create_file, fsync_parent_dir};
+use crate::fs::{
+    as_absolute, commit_md5sum_file, create_file, fsync_parent_dir, is_storage_full_error,
+};
 
 pub fn write_file<P: AsRef<Path>>(path: P, content: &[u8], mode: Option<u32>) -> Result<()> {
     debug!("Write {}", path.as_ref().display());
@@ -22,10 +24,26 @@ pub fn write_file<P: AsRef<Path>>(path: P, content: &[u8], mode: Option<u32>) ->
 
     let md5sum_path = generate_md5sum_path(&abs_path, &checksum)?;
 
-    create_file(&md5sum_path, mode, content).context(format!(
-        "Failed to create checksum file {}",
-        md5sum_path.display()
-    ))?;
+    if let Err(err) = create_file(&md5sum_path, mode, content) {
+        if is_storage_full_error(&err) {
+            warn!(
+                "Using unsafe write due to low space for {}",
+                abs_path.display()
+            );
+
+            create_file(&abs_path, mode, content)
+                .context(format!("Unsafe write filed for {}", abs_path.display()))?;
+
+            fsync_parent_dir(&abs_path)?;
+
+            return Ok(());
+        }
+
+        return Err(err).context(format!(
+            "Failed to create checksum file {}",
+            md5sum_path.display()
+        ));
+    }
 
     fsync_parent_dir(&abs_path)?;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -17,7 +17,7 @@ fn read_target_only() {
     let target = temp.join("test.txt");
     create_file(&target, test_content);
 
-    let content = read_file(target).unwrap();
+    let content = read_file(target, false).unwrap();
 
     assert_eq!(test_content, content);
 }
@@ -43,7 +43,7 @@ fn read_md5sum() {
     let tmp_path = temp.join(tmp_name);
     create_file(&tmp_path, test_md5sum_content);
 
-    let content = read_file(&target).unwrap();
+    let content = read_file(&target, false).unwrap();
 
     let committed_content = read(&target).unwrap();
 
@@ -71,7 +71,7 @@ fn read_multiple_md5sums() {
     create_file(&md5sum_path_2, test_content);
 
     let target = temp.join("test.txt");
-    let content = read_file(&target).unwrap();
+    let content = read_file(&target, false).unwrap();
 
     let committed_content = read(&target).unwrap();
 


### PR DESCRIPTION
Since the safe operations take double the size of the target file as extra space, if there is no enough space, they fail with `No space left on device (os error 28)`.

In those situations when a copy or write operation fails with no space error, we take a shortcut and resort to the unsafe counter parts of those operations.

Closes #120
