### PR TITLE
Add lacking fsync operations

### DIFF
--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -1,11 +1,14 @@
-use anyhow::{anyhow, Result};
-use log::debug;
+use anyhow::{anyhow, Context, Result};
+use log::{debug, warn};
 use md5::{Digest, Md5};
 use regex::Regex;
 
 use std::path::{Path, PathBuf};
 
-use crate::fs::get_file_name;
+use crate::fs::{
+    clean_copy, file_name_display, fsync_parent_dir, get_file_name, is_storage_full_error, read,
+    remove_file, rename,
+};
 use crate::random::generate_random_string;
 
 pub fn md5sum(content: &[u8]) -> String {
@@ -35,4 +38,85 @@ pub fn generate_md5sum_path(path: &Path, checksum: &str) -> Result<PathBuf> {
     let md5sum_path = path.with_file_name(md5sum_name);
 
     Ok(md5sum_path)
+}
+
+pub fn commit_md5sum_file(
+    md5sum_path: &Path,
+    path: &Path,
+    unsafe_fallback: bool,
+) -> Result<Vec<u8>> {
+    debug!("Committing checksum file");
+
+    let content = verify_checksum(md5sum_path)?;
+
+    let temp_path = md5sum_path.with_extension("tmp");
+
+    if let Err(err) = clean_copy(md5sum_path, &temp_path) {
+        if unsafe_fallback && is_storage_full_error(&err) {
+            warn!(
+                "Using unsafe rename due to low space for {}",
+                path.display()
+            );
+
+            rename(md5sum_path, path).context(format!(
+                "Failed to rename md5sum file to target file {} -> {}",
+                md5sum_path.display(),
+                path.display()
+            ))?;
+
+            fsync_parent_dir(path)?;
+
+            return Ok(content);
+        }
+
+        return Err(err).context(format!(
+            "Failed to copy to a temporary location {} -> {}",
+            md5sum_path.display(),
+            temp_path.display()
+        ))?;
+    }
+
+    debug!(
+        "Copied {} {}",
+        file_name_display(md5sum_path),
+        file_name_display(&temp_path)
+    );
+
+    rename(&temp_path, path).context(format!(
+        "Failed to rename temporary file to target file {} -> {}",
+        temp_path.display(),
+        path.display()
+    ))?;
+    debug!(
+        "Renamed {} {}",
+        file_name_display(&temp_path),
+        file_name_display(path)
+    );
+
+    fsync_parent_dir(path)?;
+
+    remove_file(md5sum_path).context(format!("Failed to remove {}", md5sum_path.display()))?;
+    debug!("Removed {}", file_name_display(md5sum_path));
+
+    fsync_parent_dir(path)?;
+
+    Ok(content)
+}
+
+pub fn verify_checksum(path: &Path) -> Result<Vec<u8>> {
+    let content = read(path).context(format!("Failed to read checksum file {}", path.display()))?;
+
+    let content_checksum = md5sum(&content);
+    let file_name_checksum = extract_checksum_from_path(path)?;
+
+    if content_checksum == file_name_checksum {
+        debug!("Checksum verified");
+        Ok(content)
+    } else {
+        Err(anyhow!(
+            "Content and file name checksums do not match {} != {}",
+            content_checksum,
+            file_name_checksum
+        ))
+    }
 }

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 
 use std::path::{Path, PathBuf};
 
-use crate::fs::{is_storage_full_error, read, safe_copy, safe_remove_file, safe_rename};
+use crate::fs::{is_storage_full_error, read, safe_copy, safe_remove, safe_rename};
 use crate::path::{file_name_display, get_file_name};
 use crate::random::generate_random_string;
 
@@ -89,7 +89,7 @@ pub fn commit_md5sum_file(
         file_name_display(path)
     );
 
-    safe_remove_file(md5sum_path).context(format!("Failed to remove {}", md5sum_path.display()))?;
+    safe_remove(md5sum_path).context(format!("Failed to remove {}", md5sum_path.display()))?;
     debug!("Removed {}", file_name_display(md5sum_path));
 
     Ok(content)

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -5,10 +5,8 @@ use regex::Regex;
 
 use std::path::{Path, PathBuf};
 
-use crate::fs::{
-    clean_copy, file_name_display, fsync_parent_dir, get_file_name, is_storage_full_error, read,
-    remove_file, rename,
-};
+use crate::fs::{clean_copy, fsync_parent_dir, is_storage_full_error, read, remove_file, rename};
+use crate::path::{file_name_display, get_file_name};
 use crate::random::generate_random_string;
 
 pub fn md5sum(content: &[u8]) -> String {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,8 +1,6 @@
 use anyhow::{anyhow, Context, Result};
 use log::debug;
-use path_absolutize::Absolutize;
 
-use alloc::borrow::Cow;
 use std::fs::{metadata, File, OpenOptions};
 use std::io::Result as IOResult;
 use std::io::Write;
@@ -12,42 +10,12 @@ use std::path::Path;
 
 pub use std::fs::{copy, read, remove_file, rename};
 
-pub fn as_absolute(path: &Path) -> Result<Cow<'_, Path>> {
-    path.absolutize()
-        .context(format!("Failed to absolutize {}", path.display()))
-}
-
-pub fn get_file_name(path: &Path) -> Result<String> {
-    let file_name_os = path
-        .file_name()
-        .ok_or_else(|| anyhow!("No file name in path {}", path.display()))?;
-
-    let file_name = file_name_os
-        .to_str()
-        .ok_or_else(|| anyhow!("File name is not a valid UTF-8 string {:?}", file_name_os))?;
-
-    Ok(file_name.to_owned())
-}
+use crate::path::file_name_display;
 
 pub fn get_file_mode(path: &Path) -> Result<u32> {
     let meta = metadata(path)?;
     let perm = meta.permissions();
     Ok(perm.mode())
-}
-
-pub fn get_parent_as_string(path: &Path) -> Result<String> {
-    let parent_path = path
-        .parent()
-        .ok_or_else(|| anyhow!("No parent in path {}", path.display()))?;
-
-    let parent = parent_path.to_str().ok_or_else(|| {
-        anyhow!(
-            "Parent is not a valid UTF-8 string {}",
-            parent_path.display()
-        )
-    })?;
-
-    Ok(parent.to_owned())
 }
 
 pub fn fsync_parent_dir(path: &Path) -> Result<()> {
@@ -106,10 +74,6 @@ fn open_with_mode(path: &Path, mode: Option<u32>) -> IOResult<File> {
     }
 
     open_options.open(path)
-}
-
-pub fn file_name_display(path: &Path) -> Cow<'_, str> {
-    path.file_name().unwrap_or_default().to_string_lossy()
 }
 
 pub fn is_storage_full_error(err: &std::io::Error) -> bool {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -23,11 +23,15 @@ pub fn fsync_parent_dir(path: &Path) -> Result<()> {
         .parent()
         .ok_or_else(|| anyhow!("Cannot evaluate the parent directory of {}", path.display()))?;
 
-    let f = File::open(parent_dir)
-        .context(format!("Failed to open directory {}", parent_dir.display()))?;
+    fsync_path(parent_dir)
+}
+
+fn fsync_path(path: &Path) -> Result<()> {
+    let f = File::open(path).context(format!("Failed to open path {}", path.display()))?;
     f.sync_all()
-        .context(format!("Failed to sync directory {}", parent_dir.display()))?;
-    debug!("Dir fsynced {}", parent_dir.display());
+        .context(format!("Failed to sync path {}", path.display()))?;
+
+    debug!("Fsynced {}", path.display());
 
     Ok(())
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,16 +1,16 @@
 use anyhow::{anyhow, Context, Result};
-use log::{debug, warn};
+use log::debug;
 use path_absolutize::Absolutize;
 
 use alloc::borrow::Cow;
-use std::fs::{copy, metadata, read, remove_file, rename, File, OpenOptions};
+use std::fs::{metadata, File, OpenOptions};
 use std::io::Result as IOResult;
 use std::io::Write;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
-use crate::checksum::{extract_checksum_from_path, md5sum};
+pub use std::fs::{copy, read, remove_file, rename};
 
 pub fn as_absolute(path: &Path) -> Result<Cow<'_, Path>> {
     path.absolutize()
@@ -48,87 +48,6 @@ pub fn get_parent_as_string(path: &Path) -> Result<String> {
     })?;
 
     Ok(parent.to_owned())
-}
-
-pub fn commit_md5sum_file(
-    md5sum_path: &Path,
-    path: &Path,
-    unsafe_fallback: bool,
-) -> Result<Vec<u8>> {
-    debug!("Committing checksum file");
-
-    let content = verify_checksum(md5sum_path)?;
-
-    let temp_path = md5sum_path.with_extension("tmp");
-
-    if let Err(err) = clean_copy(md5sum_path, &temp_path) {
-        if unsafe_fallback && is_storage_full_error(&err) {
-            warn!(
-                "Using unsafe rename due to low space for {}",
-                path.display()
-            );
-
-            rename(md5sum_path, path).context(format!(
-                "Failed to rename md5sum file to target file {} -> {}",
-                md5sum_path.display(),
-                path.display()
-            ))?;
-
-            fsync_parent_dir(path)?;
-
-            return Ok(content);
-        }
-
-        return Err(err).context(format!(
-            "Failed to copy to a temporary location {} -> {}",
-            md5sum_path.display(),
-            temp_path.display()
-        ))?;
-    }
-
-    debug!(
-        "Copied {} {}",
-        file_name_display(md5sum_path),
-        file_name_display(&temp_path)
-    );
-
-    rename(&temp_path, path).context(format!(
-        "Failed to rename temporary file to target file {} -> {}",
-        temp_path.display(),
-        path.display()
-    ))?;
-    debug!(
-        "Renamed {} {}",
-        file_name_display(&temp_path),
-        file_name_display(path)
-    );
-
-    fsync_parent_dir(path)?;
-
-    remove_file(md5sum_path).context(format!("Failed to remove {}", md5sum_path.display()))?;
-    debug!("Removed {}", file_name_display(md5sum_path));
-
-    fsync_parent_dir(path)?;
-
-    Ok(content)
-}
-
-pub fn verify_checksum(path: &Path) -> Result<Vec<u8>> {
-    let content = read(path).context(format!("Failed to read checksum file {}", path.display()))?;
-
-    let content_checksum = md5sum(&content);
-    let file_name_checksum = extract_checksum_from_path(path)?;
-
-    if content_checksum == file_name_checksum {
-        debug!("Checksum verified");
-        Ok(content)
-    } else {
-        Err(anyhow!(
-            "Content and file name checksums do not match {} != {}",
-            content_checksum,
-            file_name_checksum
-        ))
-    }
 }
 
 pub fn fsync_parent_dir(path: &Path) -> Result<()> {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -146,9 +146,6 @@ fn open_with_mode(path: &Path, mode: Option<u32>) -> Result<File> {
 /// This is `No space left on device (os error 28)` error.
 pub fn is_storage_full_error(err: &anyhow::Error) -> bool {
     // TODO: Use io::ErrorKind::StorageFull when stabilized
-    if let Some(e) = err.downcast_ref::<std::io::Error>() {
-        e.raw_os_error() == Some(28_i32)
-    } else {
-        false
-    }
+    err.downcast_ref::<std::io::Error>()
+        .map_or(false, |e| e.raw_os_error() == Some(28_i32))
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -22,9 +22,9 @@ pub fn get_file_mode(path: &Path) -> Result<u32> {
 ///
 /// Invokes the `unclean` version of the function and removes any left over file content
 /// in case of failure
-pub fn safe_create_file(path: &Path, mode: Option<u32>, content: &[u8]) -> Result<()> {
-    if let Err(e) = safe_create_file_unclean(path, mode, content) {
-        safe_remove_file(path).ok();
+pub fn safe_create(path: &Path, mode: Option<u32>, content: &[u8]) -> Result<()> {
+    if let Err(e) = safe_create_unclean(path, mode, content) {
+        safe_remove(path).ok();
         return Err(e);
     }
 
@@ -37,7 +37,7 @@ pub fn safe_create_file(path: &Path, mode: Option<u32>, content: &[u8]) -> Resul
 ///
 /// The `unclean` version of the function may leave incomplete left over file in case
 /// of failure.
-fn safe_create_file_unclean(path: &Path, mode: Option<u32>, content: &[u8]) -> Result<()> {
+fn safe_create_unclean(path: &Path, mode: Option<u32>, content: &[u8]) -> Result<()> {
     let mut file = open_with_mode(path, mode)?;
 
     file.write_all(content)?;
@@ -58,7 +58,7 @@ pub fn safe_copy(from: &Path, to: &Path) -> Result<()> {
     match safe_copy_unclean(from, to) {
         Ok(_) => Ok(()),
         Err(err) => {
-            safe_remove_file(to).ok();
+            safe_remove(to).ok();
             Err(err).context("Failed to copy file")
         }
     }
@@ -81,7 +81,7 @@ fn safe_copy_unclean(from: &Path, to: &Path) -> Result<u64> {
 /// Removes a file
 ///
 /// The parent dir is fsynced.
-pub fn safe_remove_file(path: &Path) -> Result<()> {
+pub fn safe_remove(path: &Path) -> Result<()> {
     remove_file(path)?;
 
     fsync_parent_dir(path)?;

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,24 +1,115 @@
 use anyhow::{anyhow, Context, Result};
 use log::debug;
 
-use std::fs::{metadata, File, OpenOptions};
-use std::io::Result as IOResult;
+use std::fs::{copy, metadata, remove_file, rename, File, OpenOptions};
 use std::io::Write;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
-pub use std::fs::{copy, read, remove_file, rename};
+pub use std::fs::read;
 
 use crate::path::file_name_display;
 
+/// Retrieves the file mode/permissions of a file
 pub fn get_file_mode(path: &Path) -> Result<u32> {
     let meta = metadata(path)?;
     let perm = meta.permissions();
     Ok(perm.mode())
 }
 
-pub fn fsync_parent_dir(path: &Path) -> Result<()> {
+/// Creates and writes and a file
+///
+/// Invokes the `unclean` version of the function and removes any left over file content
+/// in case of failure
+pub fn safe_create_file(path: &Path, mode: Option<u32>, content: &[u8]) -> Result<()> {
+    if let Err(e) = safe_create_file_unclean(path, mode, content) {
+        safe_remove_file(path).ok();
+        return Err(e);
+    }
+
+    Ok(())
+}
+
+/// Creates and writes and a file (unclean)
+///
+/// Both the file and its parent dir are fsynced.
+///
+/// The `unclean` version of the function may leave incomplete left over file in case
+/// of failure.
+fn safe_create_file_unclean(path: &Path, mode: Option<u32>, content: &[u8]) -> Result<()> {
+    let mut file = open_with_mode(path, mode)?;
+
+    file.write_all(content)?;
+    file.sync_all()?;
+
+    debug!("Created {}", file_name_display(path));
+
+    fsync_parent_dir(path)?;
+
+    Ok(())
+}
+
+/// Copies a file
+///
+/// Invokes the `unclean` version of the function and removes any left over file content
+/// in case of failure
+pub fn safe_copy(from: &Path, to: &Path) -> Result<()> {
+    match safe_copy_unclean(from, to) {
+        Ok(_) => Ok(()),
+        Err(err) => {
+            safe_remove_file(to).ok();
+            Err(err).context("Failed to copy file")
+        }
+    }
+}
+
+/// Copies a file (unclean)
+///
+/// Both the file and its parent dir are fsynced.
+///
+/// The `unclean` version of the function may leave incomplete left over file in case
+/// of failure.
+fn safe_copy_unclean(from: &Path, to: &Path) -> Result<u64> {
+    let bytes = copy(from, to)?;
+
+    fsync_file_and_parent_dir(to)?;
+
+    Ok(bytes)
+}
+
+/// Removes a file
+///
+/// The parent dir is fsynced.
+pub fn safe_remove_file(path: &Path) -> Result<()> {
+    remove_file(path)?;
+
+    fsync_parent_dir(path)?;
+
+    Ok(())
+}
+
+/// Renames a file
+///
+/// Both the file and its parent dir are fsynced.
+pub fn safe_rename(from: &Path, to: &Path) -> Result<()> {
+    rename(from, to)?;
+
+    fsync_file_and_parent_dir(to)?;
+
+    Ok(())
+}
+
+/// Fsyncs a file and its parent directory
+fn fsync_file_and_parent_dir(path: &Path) -> Result<()> {
+    fsync_path(path)?;
+    fsync_parent_dir(path)?;
+
+    Ok(())
+}
+
+/// Fsyncs the parent directory of a file
+fn fsync_parent_dir(path: &Path) -> Result<()> {
     let parent_dir = path
         .parent()
         .ok_or_else(|| anyhow!("Cannot evaluate the parent directory of {}", path.display()))?;
@@ -26,6 +117,7 @@ pub fn fsync_parent_dir(path: &Path) -> Result<()> {
     fsync_path(parent_dir)
 }
 
+/// Fsyncs a path that can be a file or directory
 fn fsync_path(path: &Path) -> Result<()> {
     let f = File::open(path).context(format!("Failed to open path {}", path.display()))?;
     f.sync_all()
@@ -36,39 +128,8 @@ fn fsync_path(path: &Path) -> Result<()> {
     Ok(())
 }
 
-pub fn create_file(path: &Path, mode: Option<u32>, content: &[u8]) -> IOResult<()> {
-    if let Err(e) = create_file_unclean(path, mode, content) {
-        // Remove any left over file content in case of failure
-        remove_file(path).ok();
-        return Err(e);
-    }
-
-    Ok(())
-}
-
-fn create_file_unclean(path: &Path, mode: Option<u32>, content: &[u8]) -> IOResult<()> {
-    let mut file = open_with_mode(path, mode)?;
-
-    file.write_all(content)?;
-    file.sync_all()?;
-
-    debug!("Created {}", file_name_display(path));
-
-    Ok(())
-}
-
-pub fn clean_copy(from: &Path, to: &Path) -> IOResult<u64> {
-    match copy(from, to) {
-        Ok(res) => Ok(res),
-        Err(err) => {
-            // Remove any left over file content in case of failure
-            remove_file(to).ok();
-            Err(err)
-        }
-    }
-}
-
-fn open_with_mode(path: &Path, mode: Option<u32>) -> IOResult<File> {
+/// Opens a file specifying file mode
+fn open_with_mode(path: &Path, mode: Option<u32>) -> Result<File> {
     let mut open_options = OpenOptions::new();
 
     open_options.create(true).write(true);
@@ -77,10 +138,17 @@ fn open_with_mode(path: &Path, mode: Option<u32>) -> IOResult<File> {
         open_options.mode(octal_mode);
     }
 
-    open_options.open(path)
+    Ok(open_options.open(path)?)
 }
 
-pub fn is_storage_full_error(err: &std::io::Error) -> bool {
+/// Checks whether a passed Error is an out-of-space error
+///
+/// This is `No space left on device (os error 28)` error.
+pub fn is_storage_full_error(err: &anyhow::Error) -> bool {
     // TODO: Use io::ErrorKind::StorageFull when stabilized
-    err.raw_os_error() == Some(28_i32)
+    if let Some(e) = err.downcast_ref::<std::io::Error>() {
+        e.raw_os_error() == Some(28_i32)
+    } else {
+        false
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ extern crate alloc;
 mod checksum;
 pub mod copy;
 mod fs;
+mod path;
 mod random;
 pub mod read;
 pub mod write;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,8 @@
     clippy::expect_used,
     clippy::missing_inline_in_public_items,
     clippy::module_name_repetitions,
-    clippy::blanket_clippy_restriction_lints
+    clippy::blanket_clippy_restriction_lints,
+    clippy::pub_use
 )]
 
 extern crate alloc;

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,0 +1,43 @@
+use anyhow::{anyhow, Context, Result};
+
+use path_absolutize::Absolutize;
+
+use std::path::Path;
+
+use alloc::borrow::Cow;
+
+pub fn as_absolute(path: &Path) -> Result<Cow<'_, Path>> {
+    path.absolutize()
+        .context(format!("Failed to absolutize {}", path.display()))
+}
+
+pub fn get_file_name(path: &Path) -> Result<String> {
+    let file_name_os = path
+        .file_name()
+        .ok_or_else(|| anyhow!("No file name in path {}", path.display()))?;
+
+    let file_name = file_name_os
+        .to_str()
+        .ok_or_else(|| anyhow!("File name is not a valid UTF-8 string {:?}", file_name_os))?;
+
+    Ok(file_name.to_owned())
+}
+
+pub fn get_parent_as_string(path: &Path) -> Result<String> {
+    let parent_path = path
+        .parent()
+        .ok_or_else(|| anyhow!("No parent in path {}", path.display()))?;
+
+    let parent = parent_path.to_str().ok_or_else(|| {
+        anyhow!(
+            "Parent is not a valid UTF-8 string {}",
+            parent_path.display()
+        )
+    })?;
+
+    Ok(parent.to_owned())
+}
+
+pub fn file_name_display(path: &Path) -> Cow<'_, str> {
+    path.file_name().unwrap_or_default().to_string_lossy()
+}

--- a/src/read.rs
+++ b/src/read.rs
@@ -6,7 +6,7 @@ use std::fs::{read, remove_file};
 use std::path::Path;
 
 use crate::checksum::commit_md5sum_file;
-use crate::fs::{as_absolute, file_name_display, get_file_name, get_parent_as_string};
+use crate::path::{as_absolute, file_name_display, get_file_name, get_parent_as_string};
 
 pub fn read_file<P: AsRef<Path>>(path: P, unsafe_fallback: bool) -> Result<Vec<u8>> {
     debug!("Read {}", path.as_ref().display());

--- a/src/read.rs
+++ b/src/read.rs
@@ -5,9 +5,8 @@ use log::debug;
 use std::fs::{read, remove_file};
 use std::path::Path;
 
-use crate::fs::{
-    as_absolute, commit_md5sum_file, file_name_display, get_file_name, get_parent_as_string,
-};
+use crate::checksum::commit_md5sum_file;
+use crate::fs::{as_absolute, file_name_display, get_file_name, get_parent_as_string};
 
 pub fn read_file<P: AsRef<Path>>(path: P, unsafe_fallback: bool) -> Result<Vec<u8>> {
     debug!("Read {}", path.as_ref().display());

--- a/src/write.rs
+++ b/src/write.rs
@@ -4,10 +4,8 @@ use log::{debug, warn};
 
 use std::path::Path;
 
-use crate::checksum::{generate_md5sum_path, md5sum};
-use crate::fs::{
-    as_absolute, commit_md5sum_file, create_file, fsync_parent_dir, is_storage_full_error,
-};
+use crate::checksum::{commit_md5sum_file, generate_md5sum_path, md5sum};
+use crate::fs::{as_absolute, create_file, fsync_parent_dir, is_storage_full_error};
 
 pub fn write_file<P: AsRef<Path>>(
     path: P,

--- a/src/write.rs
+++ b/src/write.rs
@@ -5,7 +5,7 @@ use log::{debug, warn};
 use std::path::Path;
 
 use crate::checksum::{commit_md5sum_file, generate_md5sum_path, md5sum};
-use crate::fs::{is_storage_full_error, safe_create_file};
+use crate::fs::{is_storage_full_error, safe_create};
 use crate::path::as_absolute;
 
 pub fn write_file<P: AsRef<Path>>(
@@ -28,14 +28,14 @@ pub fn write_file<P: AsRef<Path>>(
 
     let md5sum_path = generate_md5sum_path(&abs_path, &checksum)?;
 
-    if let Err(err) = safe_create_file(&md5sum_path, mode, content) {
+    if let Err(err) = safe_create(&md5sum_path, mode, content) {
         if unsafe_fallback && is_storage_full_error(&err) {
             warn!(
                 "Using unsafe write due to low space for {}",
                 abs_path.display()
             );
 
-            safe_create_file(&abs_path, mode, content)
+            safe_create(&abs_path, mode, content)
                 .context(format!("Unsafe write filed for {}", abs_path.display()))?;
 
             return Ok(());

--- a/src/write.rs
+++ b/src/write.rs
@@ -5,7 +5,8 @@ use log::{debug, warn};
 use std::path::Path;
 
 use crate::checksum::{commit_md5sum_file, generate_md5sum_path, md5sum};
-use crate::fs::{as_absolute, create_file, fsync_parent_dir, is_storage_full_error};
+use crate::fs::{create_file, fsync_parent_dir, is_storage_full_error};
+use crate::path::as_absolute;
 
 pub fn write_file<P: AsRef<Path>>(
     path: P,


### PR DESCRIPTION
Added is missing file `fsync` to `copy` and `rename` operations. Previously we only did `fsync` on the parent folder for those operations, but that was not enough and additional `fsync` on the target file itself was needed.

In particular the last `rename` that we use when writing a file did not had a file `fsync`, but only a parent directory `fsync`, which led to the target file being truncated on power cycle - without the necessary md5sum file with the file content next to it required for restoring it after the reboot.

Because of the missing fsync additionally a `FSCK0000.REC` file was dumped on the boot partition after balenaOS booted back and now after the fix I do not see those being left anymore.

Now all filesystem functions that need syncing are wrapped in a `safe` counterpart
functions:  `fatrw::fs::safe_create`, `fatrw::fs::safe_copy`, `fatrw::fs::safe_remove` and `fatrw::fs::safe_rename`.

Each of the `safe` versions sync both the target file and its parent directory.
This way no `fsync` is needed outside of those functions and thus `fsync` operations cannot
be missed when using the `safe` variants.

Additionally some functions from the `fatrw::fs` module are moved to better locations to remove clutter.

Multiple rounds manual testing for verification were done to confirm the issue is resolved.
