### PR TITLE
Disable printing log level in debug mode

### DIFF
--- a/src/bin/fatrw/main.rs
+++ b/src/bin/fatrw/main.rs
@@ -37,6 +37,7 @@ fn init_logging(cli: &Cli) {
 
     builder.format_timestamp(None);
     builder.format_target(false);
+    builder.format_level(false);
 
     if cli.debug {
         builder.filter_level(log::LevelFilter::Debug);


### PR DESCRIPTION
Log level is not really needed as in debug mode only debug messages are being printed.
